### PR TITLE
🐳 Get publisher from Sonatype

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,7 +11,7 @@ RUN mkdir -p /root/.fhir/packages
 
 COPY tools.json /app/
 
-RUN wget -P /app $(cat /app/tools.json | jq -r '.publisher.link')
+RUN wget --output-document=/app/org.hl7.fhir.publisher.jar "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.hl7.fhir.publisher&a=org.hl7.fhir.publisher.cli&v=$(cat /app/tools.json | jq -r '.publisher.version' | cut -d 'v' -f 2)&e=jar"
 
 ENTRYPOINT ["java", "-jar", "/app/org.hl7.fhir.publisher.jar"]
 CMD ["/bin/bash", "-c", "echo Welcome to the FHIR IG Publisher"]


### PR DESCRIPTION
This PR makes the Docker image build download the publisher JAR from Sonatype. This PR closes #24.