### PR TITLE
🚧 Format suppressed warnings file and ⬆️ bump to 1.0.97

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 
 <ul>
  <li>Test-Cases: <a href="https://storage.googleapis.com/ig-build/test-cases.zip">v1.1.14</a> <a href="https://github.com/FHIR/fhir-test-cases/blob/master/release-notes-test-cases.md">Release Notes</a></li>
- <li>Validator: <a href="https://storage.googleapis.com/ig-build/org.hl7.fhir.validator.jar">v5.0.3</a> <a href="https://github.com/hapifhir/org.hl7.fhir.core/blob/master/release-notes-validator.md">Release Notes</a></li>
- <li>Publisher: <a href="https://storage.googleapis.com/ig-build/org.hl7.fhir.publisher.jar">v1.0.96</a> <a href="https://github.com/HL7/fhir-ig-publisher/blob/master/release-notes-publisher.md">Release Notes</a></li>
+ <li>Validator: <a href="https://storage.googleapis.com/ig-build/org.hl7.fhir.validator.jar">v5.0.4</a> <a href="https://github.com/hapifhir/org.hl7.fhir.core/blob/master/release-notes-validator.md">Release Notes</a></li>
+ <li>Publisher: <a href="https://storage.googleapis.com/ig-build/org.hl7.fhir.publisher.jar">v1.0.97</a> <a href="https://github.com/HL7/fhir-ig-publisher/blob/master/release-notes-publisher.md">Release Notes</a></li>
 </ul>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -8,8 +8,8 @@
 
 <ul>
  <li>Test-Cases: <a href="https://storage.googleapis.com/ig-build/test-cases.zip">v1.1.14</a> <a href="https://github.com/FHIR/fhir-test-cases/blob/master/release-notes-test-cases.md">Release Notes</a></li>
- <li>Validator: <a href="https://storage.googleapis.com/ig-build/org.hl7.fhir.validator.jar">v5.0.2</a> <a href="https://github.com/hapifhir/org.hl7.fhir.core/blob/master/release-notes-validator.md">Release Notes</a></li>
- <li>Publisher: <a href="https://storage.googleapis.com/ig-build/org.hl7.fhir.publisher.jar">v1.0.95</a> <a href="https://github.com/HL7/fhir-ig-publisher/blob/master/release-notes-publisher.md">Release Notes</a></li>
+ <li>Validator: <a href="https://storage.googleapis.com/ig-build/org.hl7.fhir.validator.jar">v5.0.3</a> <a href="https://github.com/hapifhir/org.hl7.fhir.core/blob/master/release-notes-validator.md">Release Notes</a></li>
+ <li>Publisher: <a href="https://storage.googleapis.com/ig-build/org.hl7.fhir.publisher.jar">v1.0.96</a> <a href="https://github.com/HL7/fhir-ig-publisher/blob/master/release-notes-publisher.md">Release Notes</a></li>
 </ul>
 
 </body>

--- a/test/ig-site/input/ignoreWarnings.txt
+++ b/test/ig-site/input/ignoreWarnings.txt
@@ -1,0 +1,1 @@
+== Suppressed Messages ==

--- a/tools.json
+++ b/tools.json
@@ -4,11 +4,11 @@
     "link" : "https://storage.googleapis.com/ig-build/test-cases.zip"
   },
   "validator" : {
-    "version" : "v5.0.3-SNAPSHOT",
+    "version" : "v5.0.4-SNAPSHOT",
     "link" : "https://storage.googleapis.com/ig-build/org.hl7.fhir.validator.jar"
   },
   "publisher" : {
-    "version" : "v1.0.96-SNAPSHOT",
+    "version" : "v1.0.97-SNAPSHOT",
     "link" : "https://storage.googleapis.com/ig-build/org.hl7.fhir.publisher.jar"
   }
 }

--- a/tools.json
+++ b/tools.json
@@ -4,11 +4,11 @@
     "link" : "https://storage.googleapis.com/ig-build/test-cases.zip"
   },
   "validator" : {
-    "version" : "v5.0.2-SNAPSHOT",
+    "version" : "v5.0.3-SNAPSHOT",
     "link" : "https://storage.googleapis.com/ig-build/org.hl7.fhir.validator.jar"
   },
   "publisher" : {
-    "version" : "v1.0.95-SNAPSHOT",
+    "version" : "v1.0.96-SNAPSHOT",
     "link" : "https://storage.googleapis.com/ig-build/org.hl7.fhir.publisher.jar"
   }
 }


### PR DESCRIPTION
This PR 1) formats `test/ig-site/input/ignoreWarnings.txt`, adding a file header and 2) bumps publisher to 1.0.97.

This PR closes #26.