### PR TITLE
♻️ Fetch IG Publisher Script

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,7 +24,7 @@ jobs:
           - run:
               name: 'Push publisher docker image to DockerHub'
               command: |
-                if [ $CIRCLE_BRANCH != 'master' ]; then
+                if [ $CIRCLE_BRANCH == 'master' ]; then
                     GIT_COMMIT=$(git rev-parse HEAD)
                     VERSION=$(cat tools.json | jq -r '.publisher.version')
                     docker login -u kidsfirstdrc -p $KF_DOCKER_HUB_PW

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@
 
 # Except
 !/*.json
+!scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,9 +9,9 @@ RUN gem install bundler jekyll
 
 RUN mkdir -p /root/.fhir/packages
 
-COPY tools.json /app/
+COPY tools.json scripts/fetch_publisher_jar.sh /app/
 
-RUN wget --output-document=/app/org.hl7.fhir.publisher.jar "https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.hl7.fhir.publisher&a=org.hl7.fhir.publisher.cli&v=$(cat /app/tools.json | jq -r '.publisher.version' | cut -d 'v' -f 2)&e=jar"
+RUN ./fetch_publisher_jar.sh
 
 ENTRYPOINT ["java", "-jar", "/app/org.hl7.fhir.publisher.jar"]
 CMD ["/bin/bash", "-c", "echo Welcome to the FHIR IG Publisher"]

--- a/scripts/fetch_publisher_jar.sh
+++ b/scripts/fetch_publisher_jar.sh
@@ -1,0 +1,14 @@
+#! /bin/bash
+
+# Fetch a version of the IG publisher jar from its remote storage location
+# Get the version from the tools.json file
+
+set -eo pipefail
+
+EXTRACT_VERSION=$(cat tools.json | jq -r '.publisher.version' | cut -d 'v' -f 2)
+VERSION=${1:-$EXTRACT_VERSION}
+
+echo "Fetching IG Publisher version $VERSION"
+
+JAR_LOCATION="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.hl7.fhir.publisher&a=org.hl7.fhir.publisher.cli&v=$VERSION&e=jar"
+wget --output-document=org.hl7.fhir.publisher.jar "$JAR_LOCATION"


### PR DESCRIPTION
Factor out the functionality that fetches the IG publisher from the Dockerfile into a script. This will allow people to use this script to get the publisher jar by version on their local machine.