### PR TITLE
🔧 Use curl instead of wget

### DIFF
--- a/scripts/fetch_publisher_jar.sh
+++ b/scripts/fetch_publisher_jar.sh
@@ -11,4 +11,4 @@ VERSION=${1:-$EXTRACT_VERSION}
 echo "Fetching IG Publisher version $VERSION"
 
 JAR_LOCATION="https://oss.sonatype.org/service/local/artifact/maven/redirect?r=snapshots&g=org.hl7.fhir.publisher&a=org.hl7.fhir.publisher.cli&v=$VERSION&e=jar"
-wget --output-document=org.hl7.fhir.publisher.jar "$JAR_LOCATION"
+curl -L "$JAR_LOCATION" -o org.hl7.fhir.publisher.jar


### PR DESCRIPTION
Just a small thing I ran across going through the tutorial, wget isn't installed on stock OS X, so this is just one less thing to install. 